### PR TITLE
Fix deprecation errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 
         "propel/propel": "dev-master",
         "propel/propel-bundle": "4.0.*-dev",
-        "friendsofsymfony/rest-bundle": "~2.3.1",
+        "friendsofsymfony/rest-bundle": "^2.3.1",
         "jms/serializer-bundle": "~2.4.0",
         "predis/predis": "^1.1.1",
         "potaka/knp-paginator-propel2bundle": "0.* || 1.*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 
         "propel/propel": "dev-master",
         "propel/propel-bundle": "4.0.*-dev",
-        "friendsofsymfony/rest-bundle": "dev-master#06c99ba987e3813a02abf266c66c6f48b3cea9f2 as 2.3.2",
+        "friendsofsymfony/rest-bundle": "~2.3.1",
         "jms/serializer-bundle": "~2.4.0",
         "predis/predis": "^1.1.1",
         "potaka/knp-paginator-propel2bundle": "0.* || 1.*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 
         "propel/propel": "dev-master",
         "propel/propel-bundle": "4.0.*-dev",
-        "friendsofsymfony/rest-bundle": "^2.3.1",
+        "friendsofsymfony/rest-bundle": "dev-master#06c99ba987e3813a02abf266c66c6f48b3cea9f2 as 2.3.2",
         "jms/serializer-bundle": "~2.4.0",
         "predis/predis": "^1.1.1",
         "potaka/knp-paginator-propel2bundle": "0.* || 1.*",

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -30,5 +30,5 @@ tekstove_api_user_routing:
 
 tekstove_api_languages:
     path: /languages
-    defaults: { _controller: App\Controller\Language\LanguagesController:indexAction, _format: json }
+    defaults: { _controller: App\Controller\Language\LanguagesController::indexAction, _format: json }
     methods: [GET]

--- a/config/routes/routing/album.yml
+++ b/config/routes/routing/album.yml
@@ -1,29 +1,29 @@
 tekstove_api_album_credentials_new_albums:
     path: "/credentials"
-    defaults: { _controller: App\Controller\Album\CredentialsController:indexAction, id: ~ }
+    defaults: { _controller: App\Controller\Album\CredentialsController::indexAction, id: ~ }
     methods: [GET]
 
 tekstove_api_album_credentials:
     path: "/credentials/{id}"
-    defaults: { _controller: App\Controller\Album\CredentialsController:indexAction }
+    defaults: { _controller: App\Controller\Album\CredentialsController::indexAction }
     methods: [GET]
 
 tekstove_api_album_post:
     path: "/"
-    defaults: { _controller: App\Controller\AlbumController:postAction }
+    defaults: { _controller: App\Controller\AlbumController::postAction }
     methods: [POST]
 
 tekstove_api_album_patch:
     path: "/{id}"
-    defaults: { _controller: App\Controller\AlbumController:patchAction }
+    defaults: { _controller: App\Controller\AlbumController::patchAction }
     methods: [PATCH]
 
 tekstove_api_album_get:
     path: "/{id}"
-    defaults: { _controller: App\Controller\AlbumController:getAction }
+    defaults: { _controller: App\Controller\AlbumController::getAction }
     methods: [GET]
 
 tekstove_api_album_index:
     path: "/"
-    defaults: { _controller: App\Controller\AlbumController:indexAction }
+    defaults: { _controller: App\Controller\AlbumController::indexAction }
     methods: [GET]

--- a/config/routes/routing/artist.yml
+++ b/config/routes/routing/artist.yml
@@ -5,15 +5,15 @@ tekstove_api_artist:
 
 tekstove_api_artist.get:
     path: "/{id}"
-    defaults: { _controller: App\Controller\ArtistController:getAction }
+    defaults: { _controller: App\Controller\ArtistController::getAction }
     methods: [GET]
 
 tekstove_api_artist.patch:
     path: "/{id}"
-    defaults: { _controller: App\Controller\ArtistController:patchAction }
+    defaults: { _controller: App\Controller\ArtistController::patchAction }
     methods: [PATCH]
 
 tekstove_api_artist_credentials:
     path: "/credentials/{id}"
-    defaults: { _controller: App\Controller\Artist\CredentialsController:indexAction }
+    defaults: { _controller: App\Controller\Artist\CredentialsController::indexAction }
     methods: [GET]

--- a/config/routes/routing/chat.yml
+++ b/config/routes/routing/chat.yml
@@ -1,29 +1,29 @@
 tekstove_api_chat_messages_index:
     path: "/messages"
-    defaults: { _controller: App\Controller\Chat\MessagesController:indexAction }
+    defaults: { _controller: App\Controller\Chat\MessagesController::indexAction }
     methods: [GET]
 
 tekstove_api_chat_message_censore_post:
     path: "/messages/censore"
-    defaults: { _controller: App\Controller\Chat\Message\CensoreController:postAction }
+    defaults: { _controller: App\Controller\Chat\Message\CensoreController::postAction }
     methods: [POST]
 
 tekstove_api_message_ban_post:
     path: "/messages/ban"
-    defaults: { _controller: App\Controller\Chat\Message\BanController:postAction }
+    defaults: { _controller: App\Controller\Chat\Message\BanController::postAction }
     methods: [POST]
 
 tekstove_api_chat_messages_post:
     path: "/messages"
-    defaults: { _controller: App\Controller\Chat\MessagesController:postAction }
+    defaults: { _controller: App\Controller\Chat\MessagesController::postAction }
     methods: [POST]
 
 tekstove_api_chat_online_index:
     path: "/online"
-    defaults: { _controller: App\Controller\Chat\OnlineController:indexAction }
+    defaults: { _controller: App\Controller\Chat\OnlineController::indexAction }
     methods: [GET]
 
 tekstove_api_chat_online_post:
     path: "/online"
-    defaults: { _controller: App\Controller\Chat\OnlineController:postAction }
+    defaults: { _controller: App\Controller\Chat\OnlineController::postAction }
     methods: [POST]

--- a/config/routes/routing/forum.yml
+++ b/config/routes/routing/forum.yml
@@ -1,34 +1,34 @@
 tekstove_api_forum_category_index:
     path: "/category/"
-    defaults: { _controller: App\Controller\Forum\CategoryController:indexAction }
+    defaults: { _controller: App\Controller\Forum\CategoryController::indexAction }
     methods: [GET]
 
 tekstove_api_forum_category_get:
     path: "/category/{id}"
-    defaults: { _controller: App\Controller\Forum\CategoryController:getAction }
+    defaults: { _controller: App\Controller\Forum\CategoryController::getAction }
     methods: [GET]
 
 tekstove_api_forum_topic_index:
     path: "/topic/"
-    defaults: { _controller: App\Controller\Forum\TopicController:indexAction }
+    defaults: { _controller: App\Controller\Forum\TopicController::indexAction }
     methods: [GET]
 
 tekstove_api_forum_topic_:
     path: "/topic/"
-    defaults: { _controller: App\Controller\Forum\TopicController:postAction }
+    defaults: { _controller: App\Controller\Forum\TopicController::postAction }
     methods: [POST]
 
 tekstove_api_forum_topic_get:
     path: "/topic/{id}"
-    defaults: { _controller: App\Controller\Forum\TopicController:getAction }
+    defaults: { _controller: App\Controller\Forum\TopicController::getAction }
     methods: [GET]
 
 tekstove_api_forum_post_index:
     path: "/post/"
-    defaults: { _controller: App\Controller\Forum\PostController:indexAction }
+    defaults: { _controller: App\Controller\Forum\PostController::indexAction }
     methods: [GET]
 
 tekstove_api_forum_post_post:
     path: "/post/"
-    defaults: { _controller: App\Controller\Forum\PostController:postAction }
+    defaults: { _controller: App\Controller\Forum\PostController::postAction }
     methods: [POST]

--- a/config/routes/routing/lyric.yml
+++ b/config/routes/routing/lyric.yml
@@ -1,40 +1,40 @@
 tekstove_api_lyric.popularity.top.index:
     path: "/popularity/history"
-    defaults: { _controller: App\Controller\Lyric\TopPopularityController:indexAction }
+    defaults: { _controller: App\Controller\Lyric\TopPopularityController::indexAction }
     methods: [GET]
 
 tekstove_api_lyric:
     path: "/"
-    defaults: { _controller: App\Controller\LyricController:indexAction }
+    defaults: { _controller: App\Controller\LyricController::indexAction }
     methods: [GET]
 
 tekstove_api_lyric_credentials:
     path: "/credentials/{id}"
-    defaults: { _controller: App\Controller\Lyric\CredentialsController:indexAction }
+    defaults: { _controller: App\Controller\Lyric\CredentialsController::indexAction }
     methods: [GET]
 
 tekstove_api_lyric_credentials_new_lyric:
     path: "/credentials/"
-    defaults: { _controller: App\Controller\Lyric\CredentialsController:indexAction, id: ~ }
+    defaults: { _controller: App\Controller\Lyric\CredentialsController::indexAction, id: ~ }
     methods: [GET]
 
 tekstove_api_lyric_get:
     path: "/{id}"
-    defaults: { _controller: App\Controller\LyricController:getAction }
+    defaults: { _controller: App\Controller\LyricController::getAction }
     methods: [GET]
 
 tekstove_api_lyric_post:
     path: "/"
-    defaults: { _controller: App\Controller\LyricController:postAction }
+    defaults: { _controller: App\Controller\LyricController::postAction }
     methods: [POST]
 
 tekstove_api_lyric_patch:
     path: "/{id}"
-    defaults: { _controller: App\Controller\LyricController:patchAction }
+    defaults: { _controller: App\Controller\LyricController::patchAction }
     methods: [PATCH]
 
 tekstove_api_lyric.delete:
     path: "/{id}"
-    defaults: { _controller: App\Controller\LyricController:deleteAction }
+    defaults: { _controller: App\Controller\LyricController::deleteAction }
     methods: [DELETE]
 

--- a/config/routes/routing/user.yml
+++ b/config/routes/routing/user.yml
@@ -42,40 +42,40 @@ tekstove_api_user_login_get:
 
 tekstove_api_user_credentials_list:
     path: "/credentials/"
-    defaults: { _controller: App\Controller\UserCredentialsController:indexAction }
+    defaults: { _controller: App\Controller\UserCredentialsController::indexAction }
     methods: [GET]
 
 tekstove_api_user_credentials:
     path: "/credentials/{id}"
-    defaults: { _controller: App\Controller\UserCredentialsController:getAction }
+    defaults: { _controller: App\Controller\UserCredentialsController::getAction }
     methods: [GET]
 
 tekstove_api.user.pm.index:
     path: "/pm/"
-    defaults: { _controller: App\Controller\User\PmController:indexAction }
+    defaults: { _controller: App\Controller\User\PmController::indexAction }
     methods: [GET]
 
 tekstove_api.user.pm.get:
     path: "/pm/{id}"
-    defaults: { _controller: App\Controller\User\PmController:getAction }
+    defaults: { _controller: App\Controller\User\PmController::getAction }
     methods: [GET]
 
 tekstove_api.user.pm.patch:
     path: "/pm/{id}"
-    defaults: { _controller:  App\Controller\User\PmController:patchAction }
+    defaults: { _controller:  App\Controller\User\PmController::patchAction }
     methods: [PATCH]
 
 tekstove_api.user.pm.post:
     path: "/pm/"
-    defaults: { _controller:  App\Controller\User\PmController:postAction }
+    defaults: { _controller:  App\Controller\User\PmController::postAction }
     methods: [POST]
 
 tekstove_api.user.password_reset.request:
     path: "/password-reset/request"
-    defaults: { _controller:  App\Controller\User\PasswordResetController:postAction }
+    defaults: { _controller:  App\Controller\User\PasswordResetController::postAction }
     methods: [POST]
 
 tekstove_api.user.password_reset.confirm:
     path: "/password-reset/confirm"
-    defaults: { _controller:  App\Controller\User\PasswordResetConfirmController:postAction }
+    defaults: { _controller:  App\Controller\User\PasswordResetConfirmController::postAction }
     methods: [POST]

--- a/config/routes/routing/user.yml
+++ b/config/routes/routing/user.yml
@@ -1,43 +1,43 @@
 tekstove_api_user:
     path: "/"
-    defaults: { _controller: App\Controller\UserController:indexAction }
+    defaults: { _controller: App\Controller\UserController::indexAction }
     methods: [GET]
 
 tekstove_api_user_register_index:
     path: "/register/"
-    defaults: { _controller: App\Controller\User\RegisterController:indexAction }
+    defaults: { _controller: App\Controller\User\RegisterController::indexAction }
     methods: [GET]
 
 tekstove_api_user_register_post:
     path: "/register/"
-    defaults: { _controller: App\Controller\User\RegisterController:postAction }
+    defaults: { _controller: App\Controller\User\RegisterController::postAction }
     methods: [POST]
 
 tekstove_api_user_get:
     path: "/{id}"
-    defaults: { _controller: App\Controller\UserController:getAction }
+    defaults: { _controller: App\Controller\UserController::getAction }
     methods: [GET]
     requirements:
         id:  \d+
 
 tekstove_api.user.patch:
     path: "/{id}"
-    defaults: { _controller:  App\Controller\UserController:patchAction }
+    defaults: { _controller:  App\Controller\UserController::patchAction }
     methods: [PATCH]
 
 tekstove_api.user.delete:
     path: "/{id}"
-    defaults: { _controller:  App\Controller\UserController:deleteAction }
+    defaults: { _controller:  App\Controller\UserController::deleteAction }
     methods: [DELETE]
 
 tekstove_api_user_login_post:
     path: "/login/"
-    defaults: { _controller: App\Controller\User\LoginController:postAction }
+    defaults: { _controller: App\Controller\User\LoginController::postAction }
     methods: [POST]
 
 tekstove_api_user_login_get:
     path: "/login"
-    defaults: { _controller: App\Controller\User\LoginController:getAction }
+    defaults: { _controller: App\Controller\User\LoginController::getAction }
     methods: [GET]
 
 tekstove_api_user_credentials_list:


### PR DESCRIPTION
There are a lot of these errors
```
mod_fcgid: stderr: Error#16384. Referencing controllers with a single colon is deprecated since Symfony 4.1. Use App\\Controller\\UserController::indexAction instead. in /var/www/tekstove-api/build/2018_07_02-22-16-18/vendor/symfony/http-kernel/Controller/ContainerControllerResolver.php : 39
```

See this https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1897